### PR TITLE
only animate with system animations enabled

### DIFF
--- a/Mopups/Mopups.Maui/Animations/AnimationHelper.cs
+++ b/Mopups/Mopups.Maui/Animations/AnimationHelper.cs
@@ -1,0 +1,16 @@
+﻿using System;
+namespace Mopups.Animations;
+
+public static class AnimationHelper
+{
+	public static bool SystemAnimationsEnabled
+	{
+		get
+		{
+#if __ANDROID__
+			return Android.Animation.ValueAnimator.AreAnimatorsEnabled();
+#endif
+			return true;
+		}
+	}
+}

--- a/Mopups/Mopups.Maui/Pages/PopupPage.cs
+++ b/Mopups/Mopups.Maui/Pages/PopupPage.cs
@@ -24,7 +24,7 @@ public partial class PopupPage : ContentPage
 
     public bool IsAnimationEnabled
     {
-        get => (bool)GetValue(IsAnimationEnabledProperty);
+        get => (bool)GetValue(IsAnimationEnabledProperty) && AnimationHelper.SystemAnimationsEnabled;
         set => SetValue(IsAnimationEnabledProperty, value);
     }
 

--- a/Mopups/Mopups.Maui/Services/PopupNavigation.cs
+++ b/Mopups/Mopups.Maui/Services/PopupNavigation.cs
@@ -58,6 +58,8 @@ public class PopupNavigation : IPopupNavigation
 
     public Task PushAsync(PopupPage page, bool animate = true)
     {
+        animate = animate && Animations.AnimationHelper.SystemAnimationsEnabled;
+
         Pushing?.Invoke(this, new PopupNavigationEventArgs(page, animate));
         _popupStack.Add(page);
 
@@ -84,7 +86,9 @@ public class PopupNavigation : IPopupNavigation
 
     public async Task PopAllAsync(bool animate = true)
     {
-        while (MopupService.Instance.PopupStack.Count > 0)
+		animate = animate && Animations.AnimationHelper.SystemAnimationsEnabled;
+
+		while (MopupService.Instance.PopupStack.Count > 0)
         {
             await PopAsync(animate);
         }
@@ -92,14 +96,18 @@ public class PopupNavigation : IPopupNavigation
 
     public Task PopAsync(bool animate = true)
     {
-        return _popupStack.Count <= 0
+		animate = animate && Animations.AnimationHelper.SystemAnimationsEnabled;
+
+		return _popupStack.Count <= 0
             ? throw new InvalidOperationException("PopupStack is empty")
             : RemovePageAsync(PopupStack[PopupStack.Count - 1], animate);
     }
 
     public Task RemovePageAsync(PopupPage page, bool animate = true)
     {
-        if (page == null)
+		animate = animate && Animations.AnimationHelper.SystemAnimationsEnabled;
+
+		if (page == null)
             throw new InvalidOperationException("Page can not be null");
 
         if (!_popupStack.Contains(page))


### PR DESCRIPTION
fixes https://github.com/LuckyDucko/Mopups/issues/77

although this is a MAUI platform issue as documented here https://github.com/dotnet/maui/issues/16476, a fix by the MAUI team seems to be in far future with .NET 8 SR3.

Recommend keeping this quick fix until the issue is solved in MAUI.

Credits to https://github.com/dotnet/maui/issues/16476#issuecomment-1753003159 for pointing out on how to check if animations are enabled.