### PR TITLE
Fixes android accessibility handling

### DIFF
--- a/Mopups/Mopups.Maui/Pages/PopupPage.cs
+++ b/Mopups/Mopups.Maui/Pages/PopupPage.cs
@@ -1,11 +1,9 @@
-﻿using System.Windows.Input;
-
-using AsyncAwaitBestPractices;
-
+﻿using AsyncAwaitBestPractices;
 using Mopups.Animations;
 using Mopups.Animations.Base;
 using Mopups.Enums;
 using Mopups.Services;
+using System.Windows.Input;
 
 namespace Mopups.Pages;
 
@@ -108,12 +106,12 @@ public partial class PopupPage : ContentPage
         set => SetValue(BackgroundClickedCommandParameterProperty, value);
     }
 
-    public static readonly BindableProperty AndroidTalkbackAccessibilityWorkaroundProperty = BindableProperty.Create(nameof(AndroidTalkbackAccessibilityWorkaround), typeof(bool), typeof(PopupPage), false);
+    public static readonly BindableProperty DisableAccessibilityHandlingProperty = BindableProperty.Create(nameof(DisableAccessibilityHandling), typeof(bool), typeof(PopupPage), false);
 
-    public bool AndroidTalkbackAccessibilityWorkaround
+    public bool DisableAccessibilityHandling
     {
-        get => (bool)GetValue(AndroidTalkbackAccessibilityWorkaroundProperty);
-        set => SetValue(AndroidTalkbackAccessibilityWorkaroundProperty, value);
+        get => (bool)GetValue(DisableAccessibilityHandlingProperty);
+        set => SetValue(DisableAccessibilityHandlingProperty, value);
     }
 
     public PopupPage()

--- a/Mopups/Mopups.Maui/Pages/PopupPage.cs
+++ b/Mopups/Mopups.Maui/Pages/PopupPage.cs
@@ -106,12 +106,12 @@ public partial class PopupPage : ContentPage
         set => SetValue(BackgroundClickedCommandParameterProperty, value);
     }
 
-    public static readonly BindableProperty DisableAccessibilityHandlingProperty = BindableProperty.Create(nameof(DisableAccessibilityHandling), typeof(bool), typeof(PopupPage), false);
+    public static readonly BindableProperty DisableAndroidAccessibilityHandlingProperty = BindableProperty.Create(nameof(DisableAndroidAccessibilityHandling), typeof(bool), typeof(PopupPage), false);
 
-    public bool DisableAccessibilityHandling
+    public bool DisableAndroidAccessibilityHandling
     {
-        get => (bool)GetValue(DisableAccessibilityHandlingProperty);
-        set => SetValue(DisableAccessibilityHandlingProperty, value);
+        get => (bool)GetValue(DisableAndroidAccessibilityHandlingProperty);
+        set => SetValue(DisableAndroidAccessibilityHandlingProperty, value);
     }
 
     public PopupPage()

--- a/Mopups/Mopups.Maui/Platforms/Android/Impl/AndroidMopups.cs
+++ b/Mopups/Mopups.Maui/Platforms/Android/Impl/AndroidMopups.cs
@@ -64,7 +64,7 @@ public class AndroidMopups : IPopupPlatform
     }
 
     //! important keeps reference to pages that accessibility has applied to. This is so accessibility can be removed properly when popup is removed. #https://github.com/LuckyDucko/Mopups/issues/93
-    readonly List<Android.Views.View?> views = [];
+    readonly List<Android.Views.View?> views = new();
     void HandleAccessibility(bool showPopup, bool disableAccessibilityHandling)
     {
         if (disableAccessibilityHandling)

--- a/Mopups/Mopups.Maui/Platforms/Android/Impl/AndroidMopups.cs
+++ b/Mopups/Mopups.Maui/Platforms/Android/Impl/AndroidMopups.cs
@@ -51,7 +51,7 @@ public class AndroidMopups : IPopupPlatform
 
         if (renderer != null)
         {
-            HandleAccessibility(false, page.DisableAccessibilityHandling);
+            HandleAccessibility(false, page.DisableAndroidAccessibilityHandling);
 
             DecoreView?.RemoveView(renderer.PlatformView as Android.Views.View);
             renderer.DisconnectHandler(); //?? no clue if works

--- a/Mopups/Mopups.Maui/Platforms/Android/Impl/AndroidMopups.cs
+++ b/Mopups/Mopups.Maui/Platforms/Android/Impl/AndroidMopups.cs
@@ -36,20 +36,13 @@ public class AndroidMopups : IPopupPlatform
 
     public Task AddAsync(PopupPage page)
     {
-        try
-        {
-            HandleAccessibility(true);
+        HandleAccessibility(true, page.DisableAccessibilityHandling);
 
-            page.Parent = MauiApplication.Current.Application.Windows[0].Content as Element;
-            var AndroidNativeView = IPopupPlatform.GetOrCreateHandler<PopupPageHandler>(page).PlatformView as Android.Views.View;
-            DecoreView?.AddView(AndroidNativeView);
+        page.Parent = MauiApplication.Current.Application.Windows[0].Content as Element;
+        var AndroidNativeView = IPopupPlatform.GetOrCreateHandler<PopupPageHandler>(page).PlatformView as Android.Views.View;
+        DecoreView?.AddView(AndroidNativeView);
 
-            return PostAsync(AndroidNativeView);
-        }
-        catch (Exception)
-        {
-            throw;
-        }
+        return PostAsync(AndroidNativeView);
     }
 
     public Task RemoveAsync(PopupPage page)
@@ -58,7 +51,7 @@ public class AndroidMopups : IPopupPlatform
 
         if (renderer != null)
         {
-            HandleAccessibility(false);
+            HandleAccessibility(false, page.DisableAccessibilityHandling);
 
             DecoreView?.RemoveView(renderer.PlatformView as Android.Views.View);
             renderer.DisconnectHandler(); //?? no clue if works
@@ -70,35 +63,50 @@ public class AndroidMopups : IPopupPlatform
         return Task.CompletedTask;
     }
 
-    static void HandleAccessibility(bool showPopup)
+    //! important keeps reference to pages that accessibility has applied to. This is so accessibility can be removed properly when popup is removed. #https://github.com/LuckyDucko/Mopups/issues/93
+    readonly List<Android.Views.View?> views = [];
+    void HandleAccessibility(bool showPopup, bool disableAccessibilityHandling)
     {
-        Page? mainPage = Application.Current?.MainPage;
-
-        if (mainPage is null)
+        if (disableAccessibilityHandling)
         {
             return;
         }
 
-        int navCount = mainPage.Navigation.NavigationStack.Count;
-        int modalCount = mainPage.Navigation.ModalStack.Count;
-
-        ProcessView(showPopup, mainPage.Handler?.PlatformView as Android.Views.View);
-
-        if (navCount > 0)
+        if (showPopup)
         {
-            ProcessView(showPopup, mainPage.Navigation?.NavigationStack[navCount - 1]?.Handler?.PlatformView as Android.Views.View);
+            Page? mainPage = Application.Current?.MainPage;
+
+            if (mainPage is null)
+            {
+                return;
+            }
+
+            views.Add(mainPage.Handler?.PlatformView as Android.Views.View);
+
+            int navCount = mainPage.Navigation.NavigationStack.Count;
+            int modalCount = mainPage.Navigation.ModalStack.Count;
+
+            if (navCount > 0)
+            {
+                views.Add(mainPage.Navigation?.NavigationStack[navCount - 1]?.Handler?.PlatformView as Android.Views.View);
+            }
+
+            if (modalCount > 0)
+            {
+                views.Add(mainPage.Navigation?.ModalStack[modalCount - 1]?.Handler?.PlatformView as Android.Views.View);
+            }
         }
 
-        if (modalCount > 0)
+        foreach (var view in views)
         {
-            ProcessView(showPopup, mainPage.Navigation?.ModalStack[modalCount - 1]?.Handler?.PlatformView as Android.Views.View);
+            ProcessView(showPopup, view);
         }
 
         static void ProcessView(bool showPopup, Android.Views.View? view)
         {
             if (view is null)
             {
-                return;   
+                return;
             }
 
             // Screen reader
@@ -110,7 +118,7 @@ public class AndroidMopups : IPopupPlatform
         }
     }
 
-    Task<bool> PostAsync(Android.Views.View? nativeView)
+    static Task<bool> PostAsync(Android.Views.View? nativeView)
     {
         if (nativeView == null)
         {

--- a/Mopups/Mopups.Maui/Platforms/Android/Impl/AndroidMopups.cs
+++ b/Mopups/Mopups.Maui/Platforms/Android/Impl/AndroidMopups.cs
@@ -36,7 +36,7 @@ public class AndroidMopups : IPopupPlatform
 
     public Task AddAsync(PopupPage page)
     {
-        HandleAccessibility(true, page.DisableAccessibilityHandling);
+        HandleAccessibility(true, page.DisableAndroidAccessibilityHandling);
 
         page.Parent = MauiApplication.Current.Application.Windows[0].Content as Element;
         var AndroidNativeView = IPopupPlatform.GetOrCreateHandler<PopupPageHandler>(page).PlatformView as Android.Views.View;


### PR DESCRIPTION
#93 

Things changed in this PR -

- Removed `AndroidTalkbackAccessibilityWorkaround`, this was left over from the Xamarin.Forms implementation and wasn't actully being used in the Maui version 
- Added `DisableAndroidAccessibilityHandling`
    - I don't imagine a lot of people needing to use this, but just prevents people adding workarounds like the one mentioned in the comments of the linked issue
- Main fix to the linked issue is keeping a list of the android views that the accessibility handling was ran against to disable the focusability  of the elements. It then uses that list to re-enable the focusability 