### PR TITLE
iOS: Popup is closing when background is touched instead of tapped

### DIFF
--- a/Mopups/Mopups.Maui/Platforms/iOS/Handler/PopupPageRenderer.cs
+++ b/Mopups/Mopups.Maui/Platforms/iOS/Handler/PopupPageRenderer.cs
@@ -42,8 +42,8 @@ namespace Mopups.Platforms.iOS
         {
             if (disposing)
             {
+                _renderer.ViewController.View?.RemoveGestureRecognizer(_tapGestureRecognizer);
                 _renderer = null; 
-                View?.RemoveGestureRecognizer(_tapGestureRecognizer);
             }
 
             base.Dispose(disposing);
@@ -53,7 +53,7 @@ namespace Mopups.Platforms.iOS
 
         private void OnTap(UITapGestureRecognizer e)
         {
-            var view = e.View;
+            var view = e.View.Subviews.First();
             var location = e.LocationInView(view);
             var subview = view.HitTest(location, null);
 
@@ -108,14 +108,14 @@ namespace Mopups.Platforms.iOS
             ModalPresentationStyle = UIModalPresentationStyle.OverCurrentContext;
             ModalTransitionStyle = UIModalTransitionStyle.CoverVertical;
 
-            View?.AddGestureRecognizer(_tapGestureRecognizer);
+            _renderer.ViewController.View?.AddGestureRecognizer(_tapGestureRecognizer);
         }
 
         public override void ViewDidUnload()
         {
             base.ViewDidUnload();
 
-            View?.RemoveGestureRecognizer(_tapGestureRecognizer);
+            _renderer.ViewController.View?.RemoveGestureRecognizer(_tapGestureRecognizer);
         }
 
         public override void ViewWillAppear(bool animated)

--- a/Mopups/Mopups.Maui/Platforms/iOS/PopupWindow.cs
+++ b/Mopups/Mopups.Maui/Platforms/iOS/PopupWindow.cs
@@ -26,12 +26,6 @@ namespace Mopups.Platforms.iOS
 
         public override UIView HitTest(CGPoint point, UIEvent? uievent)
         {
-
-            if (_stop)
-            {
-                return base.HitTest(point, uievent);
-            }
-
             var platformHandler = (PopupPageRenderer?)RootViewController;
             var renderer = platformHandler?.Handler;
             var hitTestResult = base.HitTest(point, uievent);
@@ -42,18 +36,10 @@ namespace Mopups.Platforms.iOS
             if (formsElement.InputTransparent)
                 return null!;
 
-            if ((formsElement.BackgroundInputTransparent || formsElement.CloseWhenBackgroundIsClicked ) && renderer?.PlatformView == hitTestResult)
+            if (formsElement.BackgroundInputTransparent && renderer?.PlatformView == hitTestResult)
             {
-                if (formsElement.CloseWhenBackgroundIsClicked)
-                {
-                    _stop = true;
-                }
-
                 formsElement.SendBackgroundClick();
-                if (formsElement.BackgroundInputTransparent)
-                {
-                    return null!; //fires off other handlers? If hit test returns null, it seems that other elements will process the click instead
-                }
+                return null!;
             }
             return hitTestResult;
                 


### PR DESCRIPTION
Currently on iOS, a mopup is closed when a user is touching the background instead of tapping it. This also leads to mopups always closing when the app is swiped into App Switcher mode or similar as the background is touched in the process. 
The problem is occurring because the GestureRecognizer in PopUpPageRenderer isn't working anymore (OnTap isn't called). This might also be one of the reason for the changes in the HitTest method in PopUpWindow? 
The suggested solution seems to be working but might not be the optimal solution. It attaches the Gesture Recognizer to the View from the ViewController of the PopupPageHandler and uses its Subview in the boundary check. 
The solution also seems to fix #95.
