### PR TITLE
Check for api level when checking for animations

### DIFF
--- a/Mopups/Mopups.Maui/Animations/AnimationHelper.cs
+++ b/Mopups/Mopups.Maui/Animations/AnimationHelper.cs
@@ -8,7 +8,10 @@ public static class AnimationHelper
 		get
 		{
 #if __ANDROID__
-			return Android.Animation.ValueAnimator.AreAnimatorsEnabled();
+			if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.O)
+			{
+				return Android.Animation.ValueAnimator.AreAnimatorsEnabled();
+			}
 #endif
 			return true;
 		}


### PR DESCRIPTION
Sadly I forgot to check for the api level when checking for animations on Android, so the check for AreAnimationsEnabled fails below Android 8.0. Sorry.

thanks to @LaBoss (https://github.com/LuckyDucko/Mopups/pull/88#issuecomment-1956211627)