### PR TITLE
Open popups on the main application window

### DIFF
--- a/Mopups/Mopups.Maui/Platforms/MacCatalyst/MacOSMopups.cs
+++ b/Mopups/Mopups.Maui/Platforms/MacCatalyst/MacOSMopups.cs
@@ -1,7 +1,7 @@
 ﻿using CoreGraphics;
 
 using Microsoft.Maui.Controls.Compatibility.Platform.iOS;
-
+using Microsoft.Maui.Platform;
 using Mopups.Interfaces;
 using Mopups.Pages;
 using Mopups.Platforms.MacCatalyst;
@@ -36,7 +36,16 @@ internal class MacOSMopups : IPopupPlatform
 
         if (IsiOS13OrNewer)
         {
-            var connectedScene = UIApplication.SharedApplication.ConnectedScenes.ToArray().FirstOrDefault(x => x.ActivationState == UISceneActivationState.ForegroundActive);
+            UIScene connectedScene = null;
+
+            if(page.Parent != null && page.Parent.Handler != null && page.Parent.Handler.MauiContext != null) {
+                var nativeMainPage = page.Parent.ToPlatform(page.Parent.Handler.MauiContext);
+                connectedScene = nativeMainPage.Window.WindowScene;
+            }
+            
+            if(connectedScene == null) 
+                connectedScene = UIApplication.SharedApplication.ConnectedScenes.ToArray().FirstOrDefault(x => x.ActivationState == UISceneActivationState.ForegroundActive);
+
             if (connectedScene != null && connectedScene is UIWindowScene windowScene)
                 window = new PopupWindow(windowScene);
             else

--- a/Mopups/Mopups.Maui/Platforms/iOS/iOSMopups.cs
+++ b/Mopups/Mopups.Maui/Platforms/iOS/iOSMopups.cs
@@ -30,7 +30,10 @@ internal class iOSMopups : IPopupPlatform
 
         if (IsiOS13OrNewer)
         {
-            var connectedScene = UIApplication.SharedApplication.ConnectedScenes.ToArray().FirstOrDefault(x => x.ActivationState == UISceneActivationState.ForegroundActive);
+            var connectedScene = UIApplication.SharedApplication.ConnectedScenes.ToArray()
+                .Where(scene => scene.Session.Role == UIWindowSceneSessionRole.Application)
+                .FirstOrDefault(x => x.ActivationState == UISceneActivationState.ForegroundActive);
+
             if (connectedScene != null && connectedScene is UIWindowScene windowScene)
                 window = new PopupWindow(windowScene);
             else
@@ -65,6 +68,7 @@ internal class iOSMopups : IPopupPlatform
                 .ConnectedScenes
                 .ToArray()
                 .OfType<UIWindowScene>()
+                .Where(scene => scene.Session.Role == UIWindowSceneSessionRole.Application)
                 .SelectMany(scene => scene.Windows)
                 .FirstOrDefault(window => window.IsKeyWindow);
 


### PR DESCRIPTION
If an application has multiple windows the popup might appear in the wrong window. This fix ensures that popups are only shown on the main application window.
On iOS it's enough to check that the UISceneSession.Role is Application as this should be the phone or iPad screen.
On Mac it's possible to have multiple application windows, so here we use the same scene as page.Parents window.