### PR TITLE
Null VirtualView

### DIFF
--- a/Mopups/Mopups.Maui/Platforms/iOS/PopupWindow.cs
+++ b/Mopups/Mopups.Maui/Platforms/iOS/PopupWindow.cs
@@ -24,7 +24,7 @@ namespace Mopups.Platforms.iOS
 
         }
 
-         public override UIView? HitTest(CGPoint point, UIEvent? uievent)
+        public override UIView? HitTest(CGPoint point, UIEvent? uievent)
         {
             try
             {
@@ -52,6 +52,12 @@ namespace Mopups.Platforms.iOS
             }
             catch(Exception)
             {
+                // Perform any necessary cleanup here
+                RootViewController?.View?.RemoveFromSuperview();
+                RootViewController = null;
+                Hidden = true;
+                Dispose();
+
                 return null;
             }
         }

--- a/Mopups/Mopups.Maui/Platforms/iOS/PopupWindow.cs
+++ b/Mopups/Mopups.Maui/Platforms/iOS/PopupWindow.cs
@@ -24,25 +24,36 @@ namespace Mopups.Platforms.iOS
 
         }
 
-        public override UIView HitTest(CGPoint point, UIEvent? uievent)
+         public override UIView? HitTest(CGPoint point, UIEvent? uievent)
         {
-            var platformHandler = (PopupPageRenderer?)RootViewController;
-            var renderer = platformHandler?.Handler;
-            var hitTestResult = base.HitTest(point, uievent);
-
-            if (!(platformHandler?.Handler?.VirtualView is PopupPage formsElement))
-                return hitTestResult;
-
-            if (formsElement.InputTransparent)
-                return null!;
-
-            if (formsElement.BackgroundInputTransparent && renderer?.PlatformView == hitTestResult)
+            try
             {
-                formsElement.SendBackgroundClick();
-                return null!;
+                var platformHandler = (PopupPageRenderer?)RootViewController;
+                var renderer = platformHandler?.Handler;
+                var hitTestResult = base.HitTest(point, uievent);
+
+                if(renderer?.VirtualView is null)
+                {
+                    return hitTestResult;
+                }
+
+                if(renderer.VirtualView is not PopupPage formsElement)
+                    return hitTestResult;
+
+                if(formsElement.InputTransparent)
+                    return null;
+
+                if(formsElement.BackgroundInputTransparent && renderer.PlatformView == hitTestResult)
+                {
+                    formsElement.SendBackgroundClick();
+                    return null;
+                }
+                return hitTestResult;
             }
-            return hitTestResult;
-                
+            catch(Exception)
+            {
+                return null;
+            }
         }
     }
 }


### PR DESCRIPTION
Might fix #91 

I was getting this error with a very specific use case within the app. I did this fix before resolving the underlining issue causing it.

I'm not sure what the issue was/ how I was causing it, but for some reason even though the popup was closed tapping anywhere on the screen would trigger HitTest method and then crash.

Its as if the PopupWindow was never getting cleaned up, and just sitting on top of the app.

Originally I just had `return null;` in the catch, but every time I went through this specific use case the number of `PopupWindow`  would add up and each tap, would trigger `HitTest` x number of times. So added the cleanup code, and all seemed ok after that.

_I've altered my code since, and I no longer get into the catch, so not sure what I was doing that would of caused it_ 
