### PR TITLE
Use interfaces instead of implementations 

### DIFF
--- a/Mopups/Mopups.Maui/Mopups.PreBaked/Interfaces/GenericViewModel.cs
+++ b/Mopups/Mopups.Maui/Mopups.PreBaked/Interfaces/GenericViewModel.cs
@@ -1,8 +1,6 @@
-﻿using Mopups.PreBaked.AbstractClasses;
-
-namespace Mopups.PreBaked.Interfaces
+﻿namespace Mopups.PreBaked.Interfaces
 {
-    public interface IGenericViewModel<TViewModel> where TViewModel : BasePopupViewModel
+    public interface IGenericViewModel<TViewModel> where TViewModel : IBasePopupViewModel
     {
         void SetViewModel(TViewModel viewModel);
         TViewModel GetViewModel();

--- a/Mopups/Mopups.Maui/Mopups.PreBaked/Interfaces/IBasePopupViewModel.cs
+++ b/Mopups/Mopups.Maui/Mopups.PreBaked/Interfaces/IBasePopupViewModel.cs
@@ -2,9 +2,11 @@
 
 namespace Mopups.PreBaked.Interfaces
 {
-	public interface IBasePopupViewModel
+    public interface IBasePopupViewModel
 	{
 		bool IsBusy { get; set; }
 		event PropertyChangedEventHandler PropertyChanged;
-	}
+
+        void RunOnAttachment<TPopupType>(TPopupType popupPage) where TPopupType : Pages.PopupPage;
+    }
 }

--- a/Mopups/Mopups.Maui/Mopups.PreBaked/Interfaces/IPreBakedMopupService.cs
+++ b/Mopups/Mopups.Maui/Mopups.PreBaked/Interfaces/IPreBakedMopupService.cs
@@ -1,25 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-
-using Mopups.PreBaked.AbstractClasses;
-
-using Mopups.Pages;
+﻿using Mopups.Pages;
 
 namespace Mopups.PreBaked.Interfaces
 {
-	public interface IPreBakedMopupService
+    public interface IPreBakedMopupService
 	{
 		TPopupPage AttachViewModel<TPopupPage, TViewModel>(TPopupPage popupPage, TViewModel viewModel)
 			where TPopupPage : PopupPage, IGenericViewModel<TViewModel>
-			where TViewModel : BasePopupViewModel;
+			where TViewModel : IBasePopupViewModel;
 		TPopupPage CreatePopupPage<TPopupPage>() where TPopupPage : PopupPage, new();
 		Task ForceMinimumWaitTime(Task returnableTask, int millisecondsDelay);
 		Task<TAsyncActionResult> ForceMinimumWaitTime<TAsyncActionResult>(Task<TAsyncActionResult> returnableTask, int millisecondsDelay);
 		void PopAsync<TPopupType>() where TPopupType : PopupPage, new();
 		void PopAsync<TPopupType>(Action<Exception> exceptionActionForSafeFireAndForget) where TPopupType : PopupPage, new();
 		Task<TReturnable> PushAsync<TViewModel, TPopupPage, TReturnable>(TViewModel modalViewModel)
-			where TViewModel : PopupViewModel<TReturnable>
+			where TViewModel : IPopupViewModel<TReturnable>, IBasePopupViewModel
 			where TPopupPage : PopupPage, IGenericViewModel<TViewModel>, new();
 		Task<TSyncActionResult> WrapReturnableFuncInLoader<TSyncActionResult>(Func<TSyncActionResult> action, Color loaderColour, Color loaderPopupColour, List<string> reasonsForLoader, Color textColour, int millisecondsBetweenReasons = 2000);
 		Task<TSyncActionResult> WrapReturnableFuncInLoader<TSyncActionResult, TPopupPage>(Func<TSyncActionResult> action, Color loaderColour, Color loaderPopupColour, List<string> reasonsForLoader, Color textColour, int millisecondsBetweenReasons = 2000) where TPopupPage : PopupPage, IGenericViewModel<PopupPages.Loader.LoaderViewModel>, new();

--- a/Mopups/Mopups.Maui/Mopups.PreBaked/Services/PreBakedMopupService.cs
+++ b/Mopups/Mopups.Maui/Mopups.PreBaked/Services/PreBakedMopupService.cs
@@ -75,8 +75,8 @@ namespace Mopups.PreBaked.Services
 
 		public TPopupPage AttachViewModel<TPopupPage, TViewModel>(TPopupPage popupPage, TViewModel viewModel)
 			where TPopupPage : PopupPage, IGenericViewModel<TViewModel>
-			where TViewModel : BasePopupViewModel
-		{
+			where TViewModel : IBasePopupViewModel
+        {
 			popupPage.SetViewModel(viewModel);
 			viewModel.RunOnAttachment<TPopupPage>(popupPage);
 			return popupPage;
@@ -84,8 +84,8 @@ namespace Mopups.PreBaked.Services
 
 		public async Task<TReturnable> PushAsync<TViewModel, TPopupPage, TReturnable>(TViewModel modalViewModel)
 			where TPopupPage : PopupPage, IGenericViewModel<TViewModel>, new()
-			where TViewModel : PopupViewModel<TReturnable>
-		{
+			where TViewModel : IPopupViewModel<TReturnable>, IBasePopupViewModel
+        {
 			TPopupPage popupModal = AttachViewModel(CreatePopupPage<TPopupPage>(), modalViewModel);
 			await s_popupNavigation.PushAsync(popupModal);
 			return await modalViewModel.Returnable.Task;


### PR DESCRIPTION
@LuckyDucko In my case for MVVM I use: https://learn.microsoft.com/en-us/dotnet/communitytoolkit/mvvm/

Using this library forces me to have to implement IPopupViewModel instead of using PopupViewModel directly (because of duplicated INotifyPropertyChanged implementations). This is not a problem, I have looked at how you implement it and I implement it the same way.

The problem comes from:
* The constraint of GenericViewModel with BasePopupViewModel.
* The contstraint of IPreBakedMopupService with BasePopupViewModel and PopupViewModel

And that is precisely what I have solved with this PR.