### PR TITLE
Resolve crash when navigating to PopupPage after app is sent to background

### DIFF
--- a/Mopups/Mopups.Maui/Extensions/MauiExtensions.cs
+++ b/Mopups/Mopups.Maui/Extensions/MauiExtensions.cs
@@ -1,0 +1,32 @@
+namespace Mopups.Extensions;
+
+public static class MauiExtensions
+{
+    public static IMauiContext FindMauiContext(this Element element, bool fallbackToAppMauiContext = true)
+    {
+        if (element is IElement fe && fe.Handler?.MauiContext != null)
+            return fe.Handler.MauiContext;
+
+        foreach (var parent in element.GetParentsPath())
+        {
+            if (parent is IElement parentView && parentView.Handler?.MauiContext != null)
+                return parentView.Handler.MauiContext;
+        }
+
+        return fallbackToAppMauiContext ? Application.Current?.FindMauiContext() : default;
+    }
+
+    internal static IEnumerable<Element> GetParentsPath(this Element self)
+    {
+        Element current = self;
+
+        while (!IsApplicationOrNull(current.RealParent))
+        {
+            current = current.RealParent;
+            yield return current;
+        }
+    }
+
+    internal static bool IsApplicationOrNull(object? element) =>
+        element == null || element is IApplication;
+}

--- a/Mopups/Mopups.Maui/Platforms/Android/Impl/AndroidMopups.cs
+++ b/Mopups/Mopups.Maui/Platforms/Android/Impl/AndroidMopups.cs
@@ -39,7 +39,10 @@ public class AndroidMopups : IPopupPlatform
     {
         HandleAccessibility(true, page.DisableAndroidAccessibilityHandling, page);
 
-        var handler = page.Handler ??= new PopupPageHandler(((Element)MauiApplication.Current.Application.Windows[0].Content).FindMauiContext());
+        page.Parent = MauiApplication.Current.Application.Windows[0].Content as Element;
+        page.Parent ??= MauiApplication.Current.Application.Windows[0].Content as Element;
+
+        var handler = page.Handler ??= new PopupPageHandler(page.Parent.FindMauiContext());
 
         var androidNativeView = handler.PlatformView as Android.Views.View;
         var decoreView = Platform.CurrentActivity?.Window?.DecorView as FrameLayout;

--- a/Mopups/Mopups.Maui/Platforms/Android/Impl/AndroidMopups.cs
+++ b/Mopups/Mopups.Maui/Platforms/Android/Impl/AndroidMopups.cs
@@ -1,6 +1,7 @@
 ﻿using Android.Views;
 using Android.Widget;
 using AsyncAwaitBestPractices;
+using Mopups.Extensions;
 using Mopups.Interfaces;
 using Mopups.Pages;
 using Mopups.Services;
@@ -38,10 +39,7 @@ public class AndroidMopups : IPopupPlatform
     {
         HandleAccessibility(true, page.DisableAndroidAccessibilityHandling, page);
 
-        page.Parent = MauiApplication.Current.Application.Windows[0].Content as Element;
-        page.Parent ??= MauiApplication.Current.Application.Windows[0].Content as Element;
-
-        var handler = page.Handler ??= new PopupPageHandler(page.Parent.Handler.MauiContext);
+        var handler = page.Handler ??= new PopupPageHandler(((Element)MauiApplication.Current.Application.Windows[0].Content).FindMauiContext());
 
         var androidNativeView = handler.PlatformView as Android.Views.View;
         var decoreView = Platform.CurrentActivity?.Window?.DecorView as FrameLayout;


### PR DESCRIPTION
This is a fix for a crash that occurs on Android when navigating to a PopupPage under specific conditions, such as when the application is sent to the background while a task is still running.

**Steps to Reproduce:**

1. Use a button to trigger navigation after a delay.
2. After pressing the button, send the app to the background.
3. Simulate a delay before navigating.
4. After the delay, the root navigation is reset by assigning a new `NavigationPage` to `App.Current.MainPage`, navigating to a page that, in its `OnAppearing` method, triggers a navigation to a `PopupPage`.

Example:
```
mainStackLayout.Add(new Button()
{
    Text = "MainPage2",
    Command = new AsyncCommand(async () =>
    {
        await Task.Delay(3000); // Allow time to send the app to the background
        Console.WriteLine("Navigating to page 2");
        App.Current.MainPage = new NavigationPage(new MainPage2());
    })
});
```

**Cause of the Crash:**

- The crash occurs in the `AddAsync` method of the `AndroidMopups` class when `page.Parent.Handler` is `null`. Specifically, this happens while attempting to create a new `PopupPageHandler` instance using `page.Parent.Handler.MauiContext`, which results in a null reference exception.

**Solution:**

1. Introduced a `FindMauiContext` extension method to traverse the visual tree and retrieve a valid `MauiContext` if `page.Parent.Handler.MauiContext` is `null`.
2. Updated the `AddAsync` method to use this method to ensure a valid context is available before creating the `PopupPageHandler`.

**Related Issue:**

This fix also resolves a similar issue described in [Issue #118](https://github.com/LuckyDucko/Mopups/issues/118)
> Pushing a Popup shortly after starting the App leads to a NullReferenceException, and the Popup does not get pushed. On Android, the app crashes sometimes in this situation, but only in release mode.

The changes in this PR address the root cause of this issue by ensuring a valid MauiContext is available during navigation.