### PR TITLE
Add support for XAML Hot Reload in Visual Studio (and VS Code)

### DIFF
--- a/Mopups/Mopups.Maui/Platforms/Android/Impl/AndroidMopups.cs
+++ b/Mopups/Mopups.Maui/Platforms/Android/Impl/AndroidMopups.cs
@@ -41,8 +41,8 @@ public class AndroidMopups : IPopupPlatform
     {
         HandleAccessibility(true, page.DisableAndroidAccessibilityHandling, page);
 
-        page.Parent = MauiApplication.Current.Application.Windows[0].Content as Element;
-        page.Parent ??= MauiApplication.Current.Application.Windows[0].Content as Element;
+        var mainPage = (Element)MauiApplication.Current.Application.Windows[0].Content;
+        mainPage.AddLogicalChild(page);
 
         var handler = page.Handler ??= new PopupPageHandler(page.Parent.Handler.MauiContext);
 
@@ -56,13 +56,13 @@ public class AndroidMopups : IPopupPlatform
     {
         var renderer = IPopupPlatform.GetOrCreateHandler<PopupPageHandler>(page);
 
-        if(renderer != null)
+        if (renderer != null)
         {
             HandleAccessibility(false, page.DisableAndroidAccessibilityHandling, page);
 
             DecoreView?.RemoveView(renderer.PlatformView as Android.Views.View);
             renderer.DisconnectHandler(); //?? no clue if works
-            page.Parent = null;
+            page.Parent?.RemoveLogicalChild(page);
 
             return PostAsync(DecoreView);
         }

--- a/Mopups/Mopups.Maui/Platforms/MacCatalyst/MacOSMopups.cs
+++ b/Mopups/Mopups.Maui/Platforms/MacCatalyst/MacOSMopups.cs
@@ -22,7 +22,8 @@ internal class MacOSMopups : IPopupPlatform
 
     public Task AddAsync(PopupPage page)
     {
-        page.Parent = Application.Current.MainPage;
+        var mainPage = Application.Current.MainPage;
+        mainPage.AddLogicalChild(page);
 
         page.DescendantRemoved += HandleChildRemoved;
 
@@ -102,7 +103,7 @@ internal class MacOSMopups : IPopupPlatform
         if (handler != null && viewController != null && !viewController.IsBeingDismissed)
         {
             var window = viewController.View?.Window;
-            page.Parent = null;
+            page.Parent?.RemoveLogicalChild(page);
 
             if (window != null)
             {

--- a/Mopups/Mopups.Maui/Platforms/Windows/Impl/PopupPlatformWindows.cs
+++ b/Mopups/Mopups.Maui/Platforms/Windows/Impl/PopupPlatformWindows.cs
@@ -51,7 +51,8 @@ namespace Mopups.Windows.Implementation
 
         public async Task AddAsync(PopupPage page)
         {
-            page.Parent = Application.Current.MainPage;
+            var mainPage = Application.Current.MainPage;
+            mainPage.AddLogicalChild(page);
 
             var popup = new global::Microsoft.UI.Xaml.Controls.Primitives.Popup();
 
@@ -62,16 +63,12 @@ namespace Mopups.Windows.Implementation
             // Then you can use contructor resolution instead of singletons
             // But I figured we could do that in a later PR and just work on windows here
 
-            var renderer = (PopupPageRenderer)page.ToPlatform(Application.Current.MainPage.Handler.MauiContext);
-
+            var renderer = (PopupPageRenderer)page.ToPlatform(mainPage.Handler.MauiContext);
             renderer.Prepare(popup);
             popup.Child = renderer;
 
-
             // https://github.com/microsoft/microsoft-ui-xaml/issues/3389
-            popup.XamlRoot = 
-                Application.Current.MainPage.Handler.MauiContext.Services.GetService<Microsoft.UI.Xaml.Window>().Content.XamlRoot;
-
+            popup.XamlRoot = mainPage.Handler.MauiContext.Services.GetService<Microsoft.UI.Xaml.Window>().Content.XamlRoot;
             popup.IsOpen = true;
             page.ForceLayout();
 
@@ -91,7 +88,7 @@ namespace Mopups.Windows.Implementation
                 renderer.Destroy();
 
                 Cleanup(page);
-                page.Parent = null;
+                page.Parent?.RemoveLogicalChild(page);
                 popup.Child = null;
                 popup.IsOpen = false;
             }

--- a/Mopups/Mopups.Maui/Platforms/iOS/iOSMopups.cs
+++ b/Mopups/Mopups.Maui/Platforms/iOS/iOSMopups.cs
@@ -16,7 +16,8 @@ internal class iOSMopups : IPopupPlatform
 
     public Task AddAsync(PopupPage page)
     {
-        page.Parent ??= Application.Current?.MainPage;
+        var mainPage = Application.Current.MainPage;
+        mainPage.AddLogicalChild(page);
 
         var keyWindow = GetKeyWindow(UIApplication.SharedApplication);
         if (keyWindow?.WindowLevel == UIWindowLevel.Normal)
@@ -87,7 +88,7 @@ internal class iOSMopups : IPopupPlatform
         if (handler != null && viewController != null && !viewController.IsBeingDismissed)
         {
             var window = viewController.View?.Window;
-            page.Parent = null;
+            page.Parent?.RemoveLogicalChild(page);
 
             if (window != null)
             {


### PR DESCRIPTION
Here are repro steps for what this PR is trying to fix:

1. Open Visual Studio 2022 (latest update preferred)
    * The same thing works in VS Code, but the steps may be slightly different, and you'd need the .NET MAUI extension
2. Open the solution [`SampleMopups.sln`](https://github.com/LuckyDucko/Mopups/blob/master/SampleMaui/SampleMopups.sln) from this repo
3. Build and debug (F5) for Windows Machine
    * By default, XAML Hot Reload should be enabled, but if not, ensure that it's enabled in `Tools | Options`
4. In the running sample app, click "Aswins Popup" which shows a popup based on the XAML file [`AswinPage.xaml`](https://github.com/LuckyDucko/Mopups/blob/master/SampleMaui/XAML/AswinPage.xaml)
    * Looks like this:
    * ![image](https://github.com/user-attachments/assets/2710f1e8-5fc4-482b-a8ee-4749801e1072)
5. Open `AswinPage.xaml` in Visual Studio and edit the text of the Button "Blah":
    * ![image](https://github.com/user-attachments/assets/706ccfd0-0853-4ed1-bacb-c3e492784c3a)
    * For example, change it to "Blah 2"

**RESULT:** Nothing changes in the running sample app
**EXPECT:** The XAML changes should affect the running app because XAML Hot Reload is active

![image](https://github.com/user-attachments/assets/275ca0bd-8f6b-40ca-86a4-b893c649f0a3)

# Description

The popup's page was having its Parent property set, but it wasn't really added as a child of the Parent. Since it wasn't added as a child, it isn't part of the visual tree available to Visual Studio's hot reload and live visual tree tools. This change will use the `Add/RemoveLogicalChild` methods, which will set the Parent property, and also add the popup to the parent. That allows XAML Hot Reload to work, and also the popup and its XAML will show up in the live visual tree tool window in Visual Studio:

![image](https://github.com/user-attachments/assets/8735c019-2015-4f09-bfd7-4d4e4e3ad93a)

I don't see any automated tests in this repo, but I was able to manually test out the AswinPage popup in Windows, Android emulator, and iOS simulator.

I created this PR because I was seeing feedback from Visual Studio users that XAML Hot Reload was broken in Mopups.

Thanks!