### PR TITLE
AndroidMopups: GetTopFragmentDecorView may return a fragment about to be dismissed

### DIFF
--- a/Mopups/Mopups.Maui/Platforms/Android/Impl/AndroidMopups.cs
+++ b/Mopups/Mopups.Maui/Platforms/Android/Impl/AndroidMopups.cs
@@ -184,8 +184,13 @@ public class AndroidMopups : IPopupPlatform
         {
             return null;
         }
-
-        var fragments = componentActivity.GetFragmentManager()?.Fragments;
+        
+        var fragmentManager = componentActivity.GetFragmentManager();
+        // Execute pending transactions to make sure the top fragment is not going to be affected by upcoming
+        // state change transactions.
+        fragmentManager?.ExecutePendingTransactions();
+        
+        var fragments = fragmentManager?.Fragments;
         
         if (fragments is null || !fragments.Any())
         {


### PR DESCRIPTION
When pushing a pop up, we need to make sure the view is not added to a FrameLayout about to be dismissed.

An easy way is to apply all FragmentManager's pending transactions prior to getting the top fragment view.