### PR TITLE
Fix issue in .NET 10 iOS where TranslateTo deadlocks

### DIFF
--- a/Mopups/Mopups.Maui/Animations/MoveAnimation.cs
+++ b/Mopups/Mopups.Maui/Animations/MoveAnimation.cs
@@ -77,6 +77,9 @@ public class MoveAnimation : FadeBackgroundAnimation
                 content.TranslationX = leftOffset;
             }
 
+            content.HeightRequest = content.Height;
+            content.WidthRequest = content.Width;
+
             taskList.Add(content.TranslateTo(_defaultTranslationX, _defaultTranslationY, DurationIn, EasingIn));
         }
 


### PR DESCRIPTION
Fixes #176 

Background of the problem and fix at https://github.com/dotnet/maui/issues/32586

To get this fix before it is merged, you can introduce it into your codebase with the below

```
    public class MoveAnimationFix : MoveAnimation
    {
        public override Task Appearing(View content, PopupPage page)
        {
            if (content != null)
            {
                content.HeightRequest = content.Height;
                content.WidthRequest = content.Width;
            }

            return base.Appearing(content, page);
        }
    }
```